### PR TITLE
set sound_length, updated README

### DIFF
--- a/Data/Wake Word/audio_scraping/README.md
+++ b/Data/Wake Word/audio_scraping/README.md
@@ -9,20 +9,23 @@ To run this script:
 
   3. Select an audio book from project gutenburg:      https://www.gutenberg.org/browse/categories/1
   4. Grab the url for the "Audio Book Index" file
-  5. Run the following command: <pre>$python3 scrape_gutenburg_audio.py <sound_length> <audio_book_index_file_link>...</pre>
+  5. Run the following command: <pre>$python3 scrape_gutenburg_audio.py <audio_book_index_file_link>...</pre>
 
-This data will be labeled as Non-Wake Word samples, so make sure to select an audiobook that does not contain the word "nimbus".
+  ## IMPORTANT
+  - This data will be labeled as Non-Wake Word samples, so make sure to select an audiobook that does NOT contain the word "nimbus"
+  - Before selecting an audiobook to use, make sure it has not already been downloaded by another team member.  Click the link below to see a list of already-selected audiobooks
+  https://docs.google.com/spreadsheets/d/16qjEKGVPLV9DD26VwshZuQmmn-eqI_dHJBcDHU2mPTY/edit?usp=sharing
 
-The sound_length variable is a float amount of seconds.
+  ## SCRIPTS
 
-If you wish to create your own script using pydub's export function, make sure to set your AudioSegment instantiation to the spec-adjusted instantiation.  Then you can export with your desired output file specifications.
+  - If you wish to create your own script using pydub's AudioSegment library, make sure to set your AudioSegment instantiation to the spec-adjusted instantiation.  Then you can export with your desired output file specifications
 
-Example:
-```python
-from pydub import AudioSegment
+  Example:
+  ```python
+  from pydub import AudioSegment
 
-sound = AudioSegment.from_mp3(mp3_file_name)
-sound = sound.set_frame_rate(RATE).set_channels(CHANNELS).set_sample_width(FORMAT)
+  sound = AudioSegment.from_mp3(mp3_file_name)
+  sound = sound.set_frame_rate(RATE).set_channels(CHANNELS).set_sample_width(FORMAT)
 
-# rest of code...
-```
+  # rest of code...
+  ```

--- a/Data/Wake Word/audio_scraping/scrape_gutenburg_audio.py
+++ b/Data/Wake Word/audio_scraping/scrape_gutenburg_audio.py
@@ -5,17 +5,12 @@ import os
 
 from wav_util import mp3_to_wav, split_wav
 
-# check for correct number of arguments
-if len(sys.argv) < 3:
-    print('Usage: scrape_gutenburg_audio.py <sound_length> ' \
-        '<audio_book_index_file_link>...')
-    sys.exit(0)
+SOUND_LENGTH = 2.5      # length of each sound split
 
-# get sound-bit length, raise error if non-float passed
-try:
-    sound_length = float(sys.argv[1])
-except:
-    raise ValueError('non-numeric value entered for sound bit length')
+# check for correct number of arguments
+if len(sys.argv) < 2:
+    print('Usage: scrape_gutenburg_audio.py <audio_book_index_file_link>...')
+    sys.exit(0)
 
 # apropriate regexps for common gutenburg html forms
 regexps = [r'<li><a href="mp3-16bit\/(\d+)-(\d+)\.mp3">.*\.mp3<\/a>',
@@ -28,7 +23,7 @@ mp3_link_frames = ["https://www.gutenberg.org/files/{}/mp3-16bit/{}-{}.mp3",
                     "https://www.gutenberg.org/files/{}/mp3/{}-{}.mp3"]
 
 # process each link user provides
-for i in range(2, len(sys.argv)):
+for i in range(1, len(sys.argv)):
     link = sys.argv[i]
 
     # send web request, get content
@@ -96,11 +91,12 @@ for i in range(2, len(sys.argv)):
         # export mp3 file to a wav file
         mp3_to_wav(mp3_file_name, wav_file_name)
 
-        # split wav files into multiple segments
-        split_wav(sound_length, wav_file_name, wav_split_prefix)
+        # split wav files into multiple segments of length = SOUND_LENGTH
+        split_wav(SOUND_LENGTH, wav_file_name, wav_split_prefix)
 
-        # remove file
+        # remove temporary files
         os.remove(wav_file_name)
+        os.remove(mp3_file_name)
         file_section_index += 1
 
     # print output


### PR DESCRIPTION
- Sound length for each split is now a constant 2.5 seconds 
- README has been updated to address sound length change and to include a link to google form indicating which books have already been scraped
- Fixed minor bug where tmp.mp3 files were not being deleted